### PR TITLE
修复图标导航跳转在2023.2版本后不显示问题

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "cn.therouter"
-version = "1.2.8"
+version = "1.2.9"
 
 repositories {
     maven("https://nas.therouter.cn:8443/repository/maven-public/")
@@ -13,8 +13,14 @@ repositories {
 }
 
 intellij {
-    version.set("2021.2.4")
-    type.set("IC") // Target IDE Platform
+    if (false) {
+        // 本地调试
+        //localPath.set("D:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2024.3.1.1")
+        localPath.set("C:\\Program Files\\Android\\Android Studio")
+    } else {
+        version.set("2021.2.4")
+        type.set("IC") // Target IDE Platform
+    }
     plugins.set(listOf("java"))
 }
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,13 @@
 rootProject.name = "TheRouterIdeaPlugin"
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        maven("https://oss.sonatype.org/content/repositories/snapshots/")
+        maven("https://maven.aliyun.com/repository/gradle-plugin")
+        maven("https://maven.aliyun.com/repository/central/")
+        maven("https://maven.aliyun.com/repository/public/")
+        maven("https://maven.aliyun.com/repository/google/")
+        maven("https://maven.aliyun.com/repository/jcenter/")
+    }
+}

--- a/src/main/kotlin/cn/therouter/idea/navigator/LineMarkerUtils1.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/LineMarkerUtils1.kt
@@ -14,7 +14,7 @@ import com.intellij.psi.util.PsiTreeUtil
 class LineMarkerUtils1 : LineMarkerFunction {
 
     // VirtualFilePath, All LineMarker Code
-    private var allTheRouterPsi = HashMap<String, HashSet<CodeWrapper>>()
+    private val allTheRouterPsi = HashMap<String, HashSet<CodeWrapper>>()
 
     // psiElement.hashCode(), LineMarker Info
     private val markerCache = HashMap<CodeWrapper, LineMarkerInfo<*>>()
@@ -103,8 +103,8 @@ class LineMarkerUtils1 : LineMarkerFunction {
                 try {
                     if (targetSet.isNotEmpty()) {
                         val builder = NavigationGutterIconBuilder.create(getIcon(lineMarkerCode.type))
-                        builder.setAlignment(GutterIconRenderer.Alignment.CENTER)
-                        builder.setTargets(targetSet)
+                            .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                            .setTargets(targetSet)
                         if (lineMarkerCode.type == TYPE_ROUTE_ANNOTATION || lineMarkerCode.type == TYPE_ACTION_INTERCEPT) {
                             builder.setTooltipTitle("TheRouter:跳转到使用处")
                         } else {
@@ -115,7 +115,8 @@ class LineMarkerUtils1 : LineMarkerFunction {
                         result.add(marker)
                     } else {
                         val builder = NavigationGutterIconBuilder.create(getIcon(TYPE_NONE))
-                        builder.setAlignment(GutterIconRenderer.Alignment.CENTER)
+                            .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                            .setTargets(targetSet)
                         if (lineMarkerCode.type == TYPE_ROUTE_ANNOTATION || lineMarkerCode.type == TYPE_ACTION_INTERCEPT) {
                             builder.setTooltipTitle("未发现使用:TheRouter.build(${lineMarkerCode.code})")
                         } else {

--- a/src/main/kotlin/cn/therouter/idea/navigator/LineMarkerUtils2.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/LineMarkerUtils2.kt
@@ -11,10 +11,10 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
 
 class LineMarkerUtils2 : LineMarkerFunction {
-    private var allFile = HashSet<VirtualFile>()
+    private val allFile = HashSet<VirtualFile>() // allFile的size会一直增加
 
     // filePath, allLineMarkerCode
-    private var allFileLineMarker = HashMap<String, HashSet<CodeWrapper>>()
+    private val allFileLineMarker = HashMap<String, HashSet<CodeWrapper>>()
 
     override fun main(elements: MutableList<out PsiElement>): ArrayList<LineMarkerInfo<*>> {
         createIndex(elements)
@@ -100,8 +100,8 @@ class LineMarkerUtils2 : LineMarkerFunction {
     private fun createLineMark(wrapper: CodeWrapper, set: HashSet<TargetPsiElement>): LineMarkerInfo<*>? = try {
         if (set.isNotEmpty()) {
             val builder = NavigationGutterIconBuilder.create(getIcon(wrapper.type))
-            builder.setAlignment(GutterIconRenderer.Alignment.CENTER)
-            builder.setTargets(set)
+                .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                .setTargets(set)
             if (wrapper.type == TYPE_ROUTE_ANNOTATION || wrapper.type == TYPE_ACTION_INTERCEPT) {
                 builder.setTooltipTitle("TheRouter:跳转到使用处")
             } else {
@@ -110,7 +110,8 @@ class LineMarkerUtils2 : LineMarkerFunction {
             builder.createLineMarkerInfo(wrapper.psiElement)
         } else {
             val builder = NavigationGutterIconBuilder.create(getIcon(TYPE_NONE))
-            builder.setAlignment(GutterIconRenderer.Alignment.CENTER)
+                .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                .setTargets(set)
             if (wrapper.type == TYPE_ROUTE_ANNOTATION || wrapper.type == TYPE_ACTION_INTERCEPT) {
                 builder.setTooltipTitle("未发现使用:TheRouter.build(${wrapper.code})")
             } else {

--- a/src/main/kotlin/cn/therouter/idea/navigator/LineMarkerUtils4.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/LineMarkerUtils4.kt
@@ -11,12 +11,12 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
 
 class LineMarkerUtils4 : LineMarkerFunction {
-    private var allFile = ArrayList<VirtualFile>()
+    private val allFile = ArrayList<VirtualFile>()
 
-    private var allTheRouterPsi = HashMap<VirtualFile, HashSet<CodeWrapper>>()
+    private val allTheRouterPsi = HashMap<VirtualFile, HashSet<CodeWrapper>>()
 
     // filePath, allLineMarkerCode
-    private var allFileLineMarker = HashMap<String, HashSet<CodeWrapper>>()
+    private val allFileLineMarker = HashMap<String, HashSet<CodeWrapper>>()
 
     override fun main(elements: MutableList<out PsiElement>): ArrayList<LineMarkerInfo<*>> {
         findAllTheRouterPsi(elements[0])
@@ -51,6 +51,7 @@ class LineMarkerUtils4 : LineMarkerFunction {
 
 
     private fun findAllTheRouterPsi(rootElement: PsiElement) {
+        allFile.clear()
         val scopes = GlobalSearchScope.projectScope(rootElement.project)
         val kotlinFiles = FilenameIndex.getAllFilesByExt(rootElement.project, "kt", scopes)
         val javaFiles = FilenameIndex.getAllFilesByExt(rootElement.project, "java", scopes)
@@ -129,8 +130,8 @@ class LineMarkerUtils4 : LineMarkerFunction {
             try {
                 if (targetSet.isNotEmpty()) {
                     val builder = NavigationGutterIconBuilder.create(getIcon(lineMarkerCode.type))
-                    builder.setAlignment(GutterIconRenderer.Alignment.CENTER)
-                    builder.setTargets(targetSet)
+                        .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                        .setTargets(targetSet)
                     if (lineMarkerCode.type == TYPE_ROUTE_ANNOTATION || lineMarkerCode.type == TYPE_ACTION_INTERCEPT) {
                         builder.setTooltipTitle("TheRouter:跳转到使用处")
                     } else {
@@ -139,7 +140,8 @@ class LineMarkerUtils4 : LineMarkerFunction {
                     result.add(builder.createLineMarkerInfo(lineMarkerCode.psiElement))
                 } else {
                     val builder = NavigationGutterIconBuilder.create(getIcon(TYPE_NONE))
-                    builder.setAlignment(GutterIconRenderer.Alignment.CENTER)
+                        .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                        .setTargets(targetSet)
                     if (lineMarkerCode.type == TYPE_ROUTE_ANNOTATION || lineMarkerCode.type == TYPE_ACTION_INTERCEPT) {
                         builder.setTooltipTitle("未发现使用:TheRouter.build(${lineMarkerCode.code})")
                     } else {

--- a/src/main/kotlin/cn/therouter/idea/navigator/LineMarkerUtilsTest.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/LineMarkerUtilsTest.kt
@@ -1,0 +1,165 @@
+package cn.therouter.idea.navigator
+
+import cn.therouter.idea.utils.NotifyUtil
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.*
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
+
+class LineMarkerUtilsTest : LineMarkerFunction {
+
+    override fun main(elements: MutableList<out PsiElement>): ArrayList<LineMarkerInfo<*>> {
+        val result = ArrayList<LineMarkerInfo<*>>()
+        elements.forEach {
+            process(it, result)
+        }
+        return result
+    }
+
+    private fun process(element: PsiElement, result: ArrayList<LineMarkerInfo<*>>) {
+        // 检测Route注解
+        if (element is PsiAnnotation) {
+            processAnnotation(element, result)
+        }
+        // 检测方法TheRouter方法调用
+        else if (element is PsiMethodCallExpression) {
+            processMethodCall(element, result)
+        }
+    }
+
+    private fun processAnnotation(element: PsiAnnotation, result: ArrayList<LineMarkerInfo<*>>) {
+        // 获取注解的全限定名
+        val qualifiedName = element.qualifiedName ?: return
+        // 注解名称判断
+        if (!"com.therouter.router.Route".equals(qualifiedName)) {
+            return
+        }
+        // 解析属性
+        val attributes: Array<out PsiNameValuePair> = element.parameterList.attributes
+        for (attribute in attributes) {
+            val key: String? = attribute.name
+            // value为字符串或引用
+            var value: String? = attribute.literalValue
+            if (value == null && attribute.value is PsiReferenceExpression) {
+                val ref = attribute.value as PsiReferenceExpression
+                val resolve = ref.resolve()
+                if (resolve is PsiVariable) {
+                    value = resolve.initializer?.run {
+                        StringUtil.unquoteString(text)
+                    }
+                }
+            }
+            if (value.isNullOrBlank()) {
+                return
+            }
+            // 路径已匹配
+            if ("path".equals(key, true)) {
+                // 提示
+                NotifyUtil.show(content = "${attribute.text}", icon = AllIcons.Ide.Rating)
+                // 查找对应的PSI文件对象
+                val proj = element.project
+                val scope = GlobalSearchScope.projectScope(proj)
+                // 查找跳转目标
+                val targets = HashSet<PsiElement>()
+                // 方法一: 获取所有Java文件 性能消耗比较大
+                /*val psiManager = PsiManager.getInstance(proj)
+                val javaFiles = FileTypeIndex.getFiles(JavaFileType.INSTANCE, scope) // FilenameIndex.getAllFilesByExt(proj, "java", scope)
+                for (virtualFile in javaFiles) {
+                    // 遍历文件找到调用TheRouter.build的参数
+                    val psiFile = psiManager.findFile(virtualFile)
+                    psiFile?.accept(object : JavaRecursiveElementVisitor() {
+                        override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
+                            // 检测方法调用
+                            val expRef = expression.methodExpression
+                            val expArgs = expression.argumentList
+                            val expRefName = expRef.qualifiedName
+                            if (expArgs.expressionCount != 1 || !expRefName.contains("TheRouter.")) {
+                                return
+                            }
+                            // 检测路由path
+                            val exp1 = expArgs.expressions[0]
+                            var pathValue: String? = null
+                            if (exp1 is PsiLiteralExpression) {
+                                pathValue = StringUtil.unquoteString(exp1.text)
+                            } else if (exp1 is PsiReferenceExpression) {
+                                val resolve = exp1.resolve()
+                                if (resolve is PsiVariable) {
+                                    pathValue = resolve.initializer?.run {
+                                        StringUtil.unquoteString(text)
+                                    }
+                                }
+                            }
+                            if (pathValue.isNullOrBlank() || pathValue != value) {
+                                return
+                            }
+                            targets.add(expression.navigationElement)
+                            result.add(
+                                NavigationGutterIconBuilder.create(RouteIcons.icon_from)
+                                    .setTargets(targets)
+                                    .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                                    .setTooltipTitle(pathValue.orEmpty())
+                                    .createLineMarkerInfo(element)
+                            )
+                        }
+                    })
+                }*/
+                // 方法二：一般会把路由路径定义在静态变量里面，故只查找对应的引用
+                if (attribute.value is PsiReferenceExpression) {
+                    // 获取参数
+                    val ref = attribute.value as PsiReferenceExpression
+                    val param = StringUtil.unquoteString(ref.text)
+                    if (param.isBlank()) {
+                        return
+                    }
+                    // 获取引用
+                    val refCalls = ReferencesSearch.search(ref, scope).findAll()
+                    refCalls.forEach {
+                        targets.add(it.element.navigationElement)
+                    }
+                    result.add(
+                        NavigationGutterIconBuilder.create(getIcon(TYPE_ROUTE_ANNOTATION))
+                            .setTargets(targets)
+                            .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                            .setTooltipTitle(param)
+                            .createLineMarkerInfo(element)
+                    )
+                }
+                break
+            }
+        }
+    }
+
+    private fun processMethodCall(element: PsiMethodCallExpression, result: ArrayList<LineMarkerInfo<*>>) {
+        // 检测方法调用
+        val expRef = element.methodExpression
+        val expArgs = element.argumentList
+        val expRefName = expRef.qualifiedName
+        if (expArgs.expressionCount != 1 || !expRefName.contains("TheRouter.")) {
+            return
+        }
+        val targets = HashSet<PsiElement>()
+        // 检测路由path、Service
+        val exp = expArgs.expressions[0]
+        val pathValue = StringUtil.unquoteString(exp.text)
+        if (exp is PsiReferenceExpression) {
+
+        } else if (exp is PsiClassObjectAccessExpression) {
+            val operand = exp.operand
+            targets.add(operand.navigationElement)
+        }
+        if (pathValue.isBlank()) {
+            return
+        }
+        result.add(
+            NavigationGutterIconBuilder.create(getIcon(TYPE_THEROUTER_BUILD))
+                .setTargets(targets)
+                .setAlignment(GutterIconRenderer.Alignment.CENTER)
+                .setTooltipTitle(pathValue)
+                .createLineMarkerInfo(element)
+        )
+    }
+}

--- a/src/main/kotlin/cn/therouter/idea/navigator/MyVFSListener.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/MyVFSListener.kt
@@ -1,0 +1,35 @@
+package cn.therouter.idea.navigator
+
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCopyEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+
+/**
+ * 监听VirtualFile文件变化
+ */
+open class MyVFSListener : BulkFileListener {
+    override fun before(events: MutableList<out VFileEvent>) {
+
+    }
+
+    override fun after(events: MutableList<out VFileEvent>) {
+        for (event in events) {
+            if (event.isFromRefresh || (isCode(event) && event !is VFileContentChangeEvent)) {
+                // update allFiles
+                isChanged = true
+                break
+            }
+        }
+    }
+
+    private fun isCode(event: VFileEvent): Boolean {
+        return event.path.endsWith("java") || event.path.endsWith("kt")
+    }
+
+    companion object {
+        @JvmStatic
+        var isChanged = false
+    }
+}

--- a/src/main/kotlin/cn/therouter/idea/navigator/SourceFinder.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/SourceFinder.kt
@@ -15,9 +15,10 @@ fun getRouteAnnotationCode(psiElement: PsiElement): CodeWrapper? {
         val allParams = content.split(",")
 
         var path = ""
-        allParams.forEach {
-            if (it.startsWith("path=")) {
-                path = it.substring("path=".length)
+        for (param in allParams) {
+            if (param.startsWith("path=")) {
+                path = param.substring("path=".length)
+                break
             }
         }
         if (path.isNotBlank()) {

--- a/src/main/kotlin/cn/therouter/idea/navigator/TargetPsiElement.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/TargetPsiElement.kt
@@ -1,13 +1,18 @@
 package cn.therouter.idea.navigator
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiInvalidElementAccessException
 
 open class TargetPsiElement(private val delegate: PsiElement) : PsiElement by delegate {
 
     fun getKey() = delegate.getKey()
 
     override fun getText(): String {
-        val prefix = delegate.containingFile.name
+        val prefix:String = try {
+            delegate.containingFile.name
+        } catch (_:PsiInvalidElementAccessException) {
+            ""
+        }
         val text = delegate.getKey()
         val suffix = if (text.length > 80) {
             "${text.subSequence(0, 80)}..."

--- a/src/main/kotlin/cn/therouter/idea/navigator/TheRouterLineMarker.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/TheRouterLineMarker.kt
@@ -3,7 +3,6 @@ package cn.therouter.idea.navigator
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.psi.PsiElement
-import com.intellij.util.containers.isNullOrEmpty
 import java.io.File
 import java.io.FileInputStream
 import java.util.Properties
@@ -12,6 +11,7 @@ private val utils1 = LineMarkerUtils1()
 private val utils2 = LineMarkerUtils2()
 private val utils3 = LineMarkerUtils3()
 private val utils4 = LineMarkerUtils4()
+private val utils5 = LineMarkerUtils5()
 
 class TheRouterLineMarker : LineMarkerProvider {
 
@@ -33,10 +33,12 @@ class TheRouterLineMarker : LineMarkerProvider {
                 properties.load(FileInputStream(gradleProperties))
                 val property = properties.getProperty("TheRouterPlugin")
                 function = when (property) {
+                    "off" -> null
                     "1" -> utils1
                     "2" -> utils2
                     "3" -> utils3
                     "4" -> utils4
+                    "5" -> utils5
                     else -> utils4
                 }
             } else {

--- a/src/main/kotlin/cn/therouter/idea/navigator/Utils.kt
+++ b/src/main/kotlin/cn/therouter/idea/navigator/Utils.kt
@@ -1,6 +1,6 @@
 package cn.therouter.idea.navigator
 
-import com.intellij.openapi.util.IconLoader
+import cn.therouter.idea.utils.RouteIcons
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
@@ -39,10 +39,10 @@ fun matchActionInterceptor(srcStr: String): String {
 
 fun getIcon(type: Int): Icon {
     return when (type) {
-        TYPE_ROUTE_ANNOTATION -> IconLoader.getIcon("/icon/icon_from.png", IconLoader::class.java)
-        TYPE_THEROUTER_BUILD -> IconLoader.getIcon("/icon/icon_to.png", IconLoader::class.java)
-        TYPE_ACTION_INTERCEPT -> IconLoader.getIcon("/icon/icon_from.png", IconLoader::class.java)
-        else -> IconLoader.getIcon("/icon/icon_warn.png", IconLoader::class.java)
+        TYPE_ROUTE_ANNOTATION -> RouteIcons.icon_from
+        TYPE_THEROUTER_BUILD -> RouteIcons.icon_to
+        TYPE_ACTION_INTERCEPT -> RouteIcons.icon_from
+        else -> RouteIcons.icon_warn
     }
 }
 

--- a/src/main/kotlin/cn/therouter/idea/utils/NotifyUtil.kt
+++ b/src/main/kotlin/cn/therouter/idea/utils/NotifyUtil.kt
@@ -1,0 +1,25 @@
+package cn.therouter.idea.utils
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
+import javax.swing.Icon
+
+/**
+ * 通知提示
+ */
+object NotifyUtil {
+
+    @JvmStatic
+    @JvmOverloads
+    fun show(
+        groupId: String = "router",
+        type: NotificationType = NotificationType.INFORMATION,
+        content: String,
+        icon: Icon? = null
+    ) {
+        Notifications.Bus.notify(
+            Notification(groupId, content, type).setIcon(icon)
+        )
+    }
+}

--- a/src/main/kotlin/cn/therouter/idea/utils/RouteIcons.kt
+++ b/src/main/kotlin/cn/therouter/idea/utils/RouteIcons.kt
@@ -1,0 +1,13 @@
+package cn.therouter.idea.utils
+
+import com.intellij.openapi.util.IconLoader.getIcon
+
+
+object RouteIcons {
+    @JvmField
+    val icon_from = getIcon("/icon/icon_from.png", RouteIcons::class.java)
+    @JvmField
+    val icon_to = getIcon("/icon/icon_to.png", RouteIcons::class.java)
+    @JvmField
+    val icon_warn = getIcon("/icon/icon_warn.png", RouteIcons::class.java)
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,10 +20,13 @@
                                         implementationClass="cn.therouter.idea.navigator.TheRouterLineMarker"/>
         <codeInsight.lineMarkerProvider language="JAVA"
                                         implementationClass="cn.therouter.idea.navigator.TheRouterLineMarker"/>
+        <notificationGroup id="router" displayType="BALLOON" />
     </extensions>
     <applicationListeners>
         <listener class="cn.therouter.idea.update.UpgradeComponent"
                   topic="com.intellij.openapi.project.ProjectManagerListener"/>
+        <listener class="cn.therouter.idea.navigator.MyVFSListener"
+                  topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"/>
     </applicationListeners>
 
     <actions>


### PR DESCRIPTION
1.修复lineMarkerInfo setTargets未设置报错
2.修复allcodefiles的size膨胀且重复扫描问题
3.捕获containingFile报的PsiInvalidElementAccessException错误
4.gradle.properties中增加TheRouterPlugin=off关闭图标导航跳转功能，TheRouterPlugin=5解决2023.2版本不显示图标问题